### PR TITLE
feat: split '+'-separated release groups & configurable CORS origins

### DIFF
--- a/AddictedProxy.Services.Tests/Provider/Subtitles/FetchSubtitlesJobTests.cs
+++ b/AddictedProxy.Services.Tests/Provider/Subtitles/FetchSubtitlesJobTests.cs
@@ -1,0 +1,64 @@
+using AddictedProxy.Services.Provider.Subtitle.Jobs;
+using FluentAssertions;
+
+namespace AddictedProxy.Services.Tests.Provider.Subtitles;
+
+[TestFixture]
+public class FetchSubtitlesJobTests
+{
+    [Test]
+    public void SceneMatchesFileName_MatchesGroupAfterFirstComma()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("NTb, playWEB, Kitsune", "Show.S01E01.1080p.WEB.playWEB.x264.srt")
+                         .Should().BeTrue();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_MatchesFirstGroup()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("NTb, playWEB", "Show.S01E01.1080p.WEB.NTb.x264.srt")
+                         .Should().BeTrue();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_MatchesLegacyPlusSeparatedScene()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("NTb+playWEB+Kitsune", "Show.S01E01.1080p.WEB.Kitsune.x264.srt")
+                         .Should().BeTrue();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_MatchesDotAndDashSeparatedTokens()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("AMZN.WEB-DL", "Show.S01E01.1080p.AMZN.WEBRip.x264.srt")
+                         .Should().BeTrue();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_IsCaseInsensitive()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("NTB, PLAYWEB", "Show.S01E01.1080p.WEB.playweb.x264.srt")
+                         .Should().BeTrue();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_ReturnsFalseWhenNoTokenMatches()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("NTb, playWEB", "Show.S01E01.1080p.HDTV.x264.srt")
+                         .Should().BeFalse();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_EmptySceneDoesNotMatchEverything()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName("", "Show.S01E01.1080p.HDTV.x264.srt")
+                         .Should().BeFalse();
+    }
+
+    [Test]
+    public void SceneMatchesFileName_SeparatorOnlySceneDoesNotMatch()
+    {
+        FetchSubtitlesJob.SceneMatchesFileName(", ,", "Show.S01E01.1080p.HDTV.x264.srt")
+                         .Should().BeFalse();
+    }
+}

--- a/AddictedProxy.Upstream.Tests/ParserTests.cs
+++ b/AddictedProxy.Upstream.Tests/ParserTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using AddictedProxy.Culture.Service;
+using AddictedProxy.Database.Model.Shows;
 using AddictedProxy.Upstream.Service;
 using AddictedProxy.Upstream.Service.Exception;
 using AngleSharp.Html.Parser;
@@ -428,5 +429,40 @@ pageTracker._trackPageview();
         };
 
         await act.Should().ThrowAsync<NothingToParseException>().WithMessage("Can't find episode table");
+    }
+
+    [Test]
+    public async Task Test_GetSeasonSubtitles_Splits_Plus_Separated_Scene()
+    {
+        const string html = """
+            <html>
+            <body>
+            <div id="season">
+            <table>
+            <tr><th>Season</th><th>Episode</th><th>Title</th><th>Language</th><th>Version</th><th>Status</th><th>HI</th><th>Corrected</th><th>HD</th><th>Download</th></tr>
+            <tr>
+            <td>1</td><td>2</td><td>Pilot</td><td>English</td><td>NTb+playWEB+Kitsune</td><td>100%</td><td></td><td></td><td>Yes</td>
+            <td><a href="/updated/1/234567/8">Download</a></td>
+            </tr>
+            <tr>
+            <td>1</td><td>3</td><td>Second Episode</td><td>English</td><td>AMZN.WEB-DL</td><td>100%</td><td></td><td></td><td></td>
+            <td><a href="/updated/1/234568/1">Download</a></td>
+            </tr>
+            </table>
+            </div>
+            </body>
+            </html>
+            """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(html));
+        var episodes = new List<Episode>();
+        await foreach (var episode in _parser.GetSeasonSubtitlesAsync(stream, default))
+        {
+            episodes.Add(episode);
+        }
+
+        episodes.Should().HaveCount(2);
+        episodes[0].Subtitles.Should().ContainSingle().Which.Scene.Should().Be("NTb, playWEB, Kitsune");
+        episodes[1].Subtitles.Should().ContainSingle().Which.Scene.Should().Be("AMZN.WEB-DL");
     }
 }

--- a/AddictedProxy.Upstream/Service/Parser.cs
+++ b/AddictedProxy.Upstream/Service/Parser.cs
@@ -219,7 +219,7 @@ public partial class Parser
                 var languageIsoCode = (await _cultureParser.FromStringAsync(subtitleRow.Language, token))?.Name;
                 subtitles.Add(new Subtitle
                 {
-                    Scene = subtitleRow.Scene.Trim(),
+                    Scene = NormalizeScene(subtitleRow.Scene),
                     Corrected = subtitleRow.Corrected,
                     DownloadUri = subtitleRow.DownloadUri,
                     Qualities = subtitleRow.HD ? VideoQuality.Q720P | VideoQuality.Q1080P : VideoQuality.None,
@@ -238,5 +238,16 @@ public partial class Parser
             episode.Subtitles = subtitles;
             yield return episode;
         }
+    }
+
+    /// <summary>
+    /// Addic7ed joins multiple release groups with '+' in the version column
+    /// (e.g. "NTb+playWEB+Kitsune"). Splits them into the comma-separated format
+    /// used by the SuperSubtitles source.
+    /// </summary>
+    private static string NormalizeScene(string scene)
+    {
+        var groups = scene.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return groups.Length > 0 ? string.Join(", ", groups) : scene.Trim();
     }
 }

--- a/AddictedProxy/Controllers/Bootstrap/BootstrapController.cs
+++ b/AddictedProxy/Controllers/Bootstrap/BootstrapController.cs
@@ -2,17 +2,18 @@
 
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using System.Text.RegularExpressions;
+using AddictedProxy.Controllers.Config;
 using AddictedProxy.Controllers.Rest.Serializer;
 using AddictedProxy.Services.Middleware;
 using InversionOfControl.Model;
+using Microsoft.Extensions.Options;
 using Prometheus;
 
 #endregion
 
 namespace AddictedProxy.Controllers.Bootstrap;
 
-public partial class BootstrapController : IBootstrap, IBootstrapApp
+public class BootstrapController : IBootstrap, IBootstrapApp
 {
     public void ConfigureServices(IServiceCollection services, IConfiguration configuration, ILoggingBuilder logging)
     {
@@ -26,6 +27,7 @@ public partial class BootstrapController : IBootstrap, IBootstrapApp
         services.AddHttpContextAccessor();
         services.AddHttpLogging(_ => { });
         services.AddLogging(opt => { opt.AddConsole(c => { c.TimestampFormat = "[HH:mm:ss] "; }); });
+        services.Configure<CorsConfig>(configuration.GetSection(CorsConfig.SectionName));
     }
 
     public void ConfigureApp(IApplicationBuilder app)
@@ -35,13 +37,14 @@ public partial class BootstrapController : IBootstrap, IBootstrapApp
             endpointRouteBuilder.MapControllers();
         }
 
+        var corsConfig = app.ApplicationServices.GetRequiredService<IOptions<CorsConfig>>().Value;
+
         app.UseCors(policyBuilder =>
         {
             policyBuilder
                 .AllowAnyMethod()
                 .AllowAnyHeader()
                 .AllowCredentials()
-                .SetIsOriginAllowedToAllowWildcardSubdomains()
                 .WithExposedHeaders("Content-Disposition")
                 .WithExposedHeaders("sentry-trace")
                 .WithExposedHeaders("baggage");
@@ -51,7 +54,9 @@ public partial class BootstrapController : IBootstrap, IBootstrapApp
             }
             else
             {
-                policyBuilder.SetIsOriginAllowed(hostname => CorsOriginRegex().IsMatch(hostname));
+                policyBuilder
+                    .WithOrigins(corsConfig.AllowedOrigins)
+                    .SetIsOriginAllowedToAllowWildcardSubdomains();
             }
         });
 
@@ -60,8 +65,4 @@ public partial class BootstrapController : IBootstrap, IBootstrapApp
         app.UseHttpMetrics();
         app.UseAuthorization();
     }
-    
-
-    [GeneratedRegex(@"^(https:\/\/(gestdown\.info|addictedproxy\.pages\.dev|dev\.addictedproxy\.pages\.dev)|.*\.gestdown\.info)$")]
-    private static partial Regex CorsOriginRegex();
 }

--- a/AddictedProxy/Controllers/Config/CorsConfig.cs
+++ b/AddictedProxy/Controllers/Config/CorsConfig.cs
@@ -1,0 +1,24 @@
+namespace AddictedProxy.Controllers.Config;
+
+/// <summary>
+/// Configuration for the CORS policy applied to the API.
+/// Bound from the "Cors" configuration section.
+/// </summary>
+public class CorsConfig
+{
+    public const string SectionName = "Cors";
+
+    /// <summary>
+    /// Origins allowed to call the API. Entries may use a wildcard subdomain
+    /// (e.g. "https://*.example.com"); the scheme is part of the origin.
+    /// </summary>
+    public string[] AllowedOrigins { get; set; } =
+    [
+        "https://gestdown.info",
+        "https://*.gestdown.info",
+        "https://addictedproxy.pages.dev",
+        "https://*.addictedproxy.pages.dev",
+        "https://subvault.tv",
+        "https://*.subvault.tv"
+    ];
+}

--- a/AddictedProxy/Migrations/Services/NormalizeSubtitleSceneSeparatorMigration.cs
+++ b/AddictedProxy/Migrations/Services/NormalizeSubtitleSceneSeparatorMigration.cs
@@ -1,0 +1,46 @@
+using AddictedProxy.Database.Context;
+using AddictedProxy.Database.Model.Shows;
+using AddictedProxy.OneTimeMigration.Model;
+using Hangfire.Console;
+using Hangfire.Server;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace AddictedProxy.Migrations.Services;
+
+/// <summary>
+/// One-time migration that normalizes existing Addic7ed subtitle Scene values: the Addic7ed
+/// version column joins multiple release groups with '+' (e.g. "NTb+playWEB+Kitsune"), while
+/// the parser now stores them comma-separated like the SuperSubtitles source. Scene is ignored
+/// on merge updates, so existing rows would never be refreshed by the regular ingestion pipeline.
+/// </summary>
+[MigrationDate(2026, 8, 10)]
+public class NormalizeSubtitleSceneSeparatorMigration : IMigration
+{
+    private const int Addic7edSource = (int)DataSource.Addic7ed;
+
+    private readonly EntityContext _entityContext;
+    private readonly ILogger<NormalizeSubtitleSceneSeparatorMigration> _logger;
+
+    public NormalizeSubtitleSceneSeparatorMigration(EntityContext entityContext, ILogger<NormalizeSubtitleSceneSeparatorMigration> logger)
+    {
+        _entityContext = entityContext;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(PerformContext context, CancellationToken token)
+    {
+        context.WriteLine("Normalizing '+' separators in Addic7ed subtitle Scene values...");
+        _logger.LogInformation("Normalizing '+' separators in Addic7ed subtitle Scene values...");
+
+        var updated = await _entityContext.Database.ExecuteSqlAsync(
+            $"""
+             UPDATE "Subtitles"
+             SET "Scene" = regexp_replace("Scene", '\s*\+\s*', ', ', 'g')
+             WHERE "Source" = {Addic7edSource} AND "Scene" LIKE '%+%'
+             """, token);
+
+        context.WriteLine($"Normalized {updated} Addic7ed subtitle Scene value(s).");
+        _logger.LogInformation("Normalized {Count} Addic7ed subtitle Scene value(s) containing '+'", updated);
+    }
+}

--- a/AddictedProxy/Services/Provider/Subtitle/Jobs/FetchSubtitlesJob.cs
+++ b/AddictedProxy/Services/Provider/Subtitle/Jobs/FetchSubtitlesJob.cs
@@ -160,7 +160,7 @@ public class FetchSubtitlesJob
                           .WhereAwait(async subtitle => data.Language == await _cultureParser.FromStringAsync(subtitle.Language, token));
         if (data.FileName != null)
         {
-            list = list.Where(subtitle => subtitle.Scene.ToLowerInvariant().Split('+', '.', '-').Any(version => data.FileName.ToLowerInvariant().Contains(version)));
+            list = list.Where(subtitle => subtitle.Scene.ToLowerInvariant().Split('+', '.', '-', ',').Any(version => data.FileName.ToLowerInvariant().Contains(version)));
         }
 
         return await list.AnyAsync(token);

--- a/AddictedProxy/Services/Provider/Subtitle/Jobs/FetchSubtitlesJob.cs
+++ b/AddictedProxy/Services/Provider/Subtitle/Jobs/FetchSubtitlesJob.cs
@@ -160,10 +160,25 @@ public class FetchSubtitlesJob
                           .WhereAwait(async subtitle => data.Language == await _cultureParser.FromStringAsync(subtitle.Language, token));
         if (data.FileName != null)
         {
-            list = list.Where(subtitle => subtitle.Scene.ToLowerInvariant().Split('+', '.', '-', ',').Any(version => data.FileName.ToLowerInvariant().Contains(version)));
+            var fileName = data.FileName;
+            list = list.Where(subtitle => SceneMatchesFileName(subtitle.Scene, fileName));
         }
 
         return await list.AnyAsync(token);
+    }
+
+    /// <summary>
+    /// Checks whether any release-group token from the subtitle Scene appears in the file name.
+    /// Scene tokens are separated by '+', '.', '-' or ',' (comma after the '+' normalization);
+    /// each token is trimmed and empty tokens are ignored so they cannot match every file name.
+    /// </summary>
+    internal static bool SceneMatchesFileName(string scene, string fileName)
+    {
+        var lowerFileName = fileName.ToLowerInvariant();
+        return scene.ToLowerInvariant()
+                    .Split('+', '.', '-', ',')
+                    .Select(version => version.Trim())
+                    .Any(version => version.Length > 0 && lowerFileName.Contains(version));
     }
 
     public readonly record struct JobData(long ShowId, int Season, int Episode, Culture.Model.Culture? Language, string? FileName) : IUniqueKey

--- a/AddictedProxy/appsettings.json
+++ b/AddictedProxy/appsettings.json
@@ -54,6 +54,16 @@
     "BaseUrl": "https://www.gestdown.info"
   },
   "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": [
+      "https://gestdown.info",
+      "https://*.gestdown.info",
+      "https://addictedproxy.pages.dev",
+      "https://*.addictedproxy.pages.dev",
+      "https://subvault.tv",
+      "https://*.subvault.tv"
+    ]
+  },
   "RateLimiting": {
     "Token": {
       "ReplenishmentPeriod": "00:01:00",

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ docker build -t addictedproxy .
 - Settings live in `AddictedProxy/appsettings.json` and `AddictedProxy/appsettings.Development.json`.
 - Environment variable prefix is `A7D_`.
 - SuperSubtitles import/refresh controls are under `SuperSubtitles:Import` (`EnableImport`, `EnableRefresh`, `BatchSize`, delays).
+- CORS allowed origins are under `Cors:AllowedOrigins` (wildcard subdomains supported, e.g. `https://*.example.com`); see [docs/api-surface.md](docs/api-surface.md#cors).
 
 ## Repository highlights
 

--- a/addicted.nuxt/app/composables/useGroupColor.ts
+++ b/addicted.nuxt/app/composables/useGroupColor.ts
@@ -31,10 +31,12 @@ export const useGroupColor = () => {
 };
 
 /**
- * Split a comma-separated version string into individual release group names.
+ * Split a version string into individual release group names.
+ * Handles comma-separated groups (SuperSubtitles) and legacy
+ * '+'-separated groups (Addic7ed).
  */
 export const parseReleaseGroups = (version: string): string[] =>
   version
-    .split(",")
+    .split(/[+,]/)
     .map((s) => s.trim())
     .filter(Boolean);

--- a/docs/api-surface.md
+++ b/docs/api-surface.md
@@ -233,6 +233,29 @@ record ErrorResponse(string Error);
 
 The API is **public** — no authentication is required for any endpoint. Rate limiting is applied at the proxy/infrastructure level.
 
+## CORS
+
+Cross-origin requests are governed by a single policy configured in `BootstrapController` (`AddictedProxy/Controllers/Bootstrap/BootstrapController.cs`).
+
+- **Allowed origins** come from the `Cors:AllowedOrigins` array in `appsettings.json`. Entries may use a wildcard subdomain (e.g. `https://*.example.com`), matched via ASP.NET Core's `SetIsOriginAllowedToAllowWildcardSubdomains()`. The scheme is part of the origin, so `http://` variants are rejected unless explicitly listed.
+- **Methods & headers**: any method and any request header are allowed.
+- **Credentials**: allowed (`AllowCredentials()`), which is why the origin list can never be `*`.
+- **Exposed headers**: `Content-Disposition` (subtitle download filename), `sentry-trace` and `baggage` (distributed tracing propagation).
+- **Development environment**: any origin is accepted to ease local development.
+
+Default allowed origins:
+
+| Origin pattern                       | Covers                                    |
+| ------------------------------------ | ----------------------------------------- |
+| `https://gestdown.info`              | Production frontend (apex)                |
+| `https://*.gestdown.info`            | Production frontend subdomains            |
+| `https://addictedproxy.pages.dev`    | Cloudflare Pages deployment (apex)        |
+| `https://*.addictedproxy.pages.dev`  | Cloudflare Pages preview deployments      |
+| `https://subvault.tv`                | SubVault frontend (apex)                  |
+| `https://*.subvault.tv`              | SubVault subdomains                       |
+
+To allow a new origin, add it to `Cors:AllowedOrigins` in `appsettings.json` (or via environment variables, e.g. `A7D_Cors__AllowedOrigins__0`) and redeploy.
+
 ## Response Caching Strategy
 
 | Content Type            | Cache Duration | Rationale                                    |

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -207,7 +207,7 @@ season pollution purged once.
 
 - **Environment variables**: Use `A7D_` prefix convention
 - **Settings files**: `appsettings.json` and `appsettings.Development.json`
-- **Key config sections**: Connection strings, PostgreSQL caching, rate limiting, proxy scraping, Sentry, Performance (OpenTelemetry)
+- **Key config sections**: Connection strings, PostgreSQL caching, rate limiting, proxy scraping, Sentry, Performance (OpenTelemetry), CORS allowed origins (`Cors:AllowedOrigins`, see [API Surface — CORS](api-surface.md#cors))
 - **NuGet packages**: Centrally managed in `Directory.Packages.props` at solution root
 
 ## Observability


### PR DESCRIPTION
## Summary

Two related changes:

1. **Release-group splitting**: Addic7ed joins multiple release groups with `+` in the version column (e.g. `NTb+playWEB+Kitsune+FLUX+HiggsBoson+CAKES+TURG`). This splits them into the comma-separated format already used by the SuperSubtitles source, so the frontend renders one chip per release group.
2. **Configurable CORS**: the allowed-origin list moves from a hard-coded regex into `appsettings.json` (`Cors:AllowedOrigins`), adding `*.addictedproxy.pages.dev` and `*.subvault.tv` alongside the existing `gestdown.info` origins.

## Changes

### Release-group splitting
- **`AddictedProxy.Upstream` Parser**: normalize Addic7ed `Scene` at ingestion — split on `+`, trim, join with `", "` (mirrors SuperSubtitles' `string.Join(", ", ReleaseGroups)`)
- **`FetchSubtitlesJob`**: filename matching splits on `','` too, trims tokens and discards empty ones (extracted to `SceneMatchesFileName`, per review feedback)
- **One-time migration** (`NormalizeSubtitleSceneSeparatorMigration`): `regexp_replace` existing Addic7ed `Scene` values (`\s*\+\s*` → `", "`). Required because `EpisodeRepository.UpsertEpisodes` ignores `Scene` on merge updates, so existing rows never self-heal through the ingestion pipeline
- **Frontend** `parseReleaseGroups`: split on both `,` and `+` so any pre-migration data still renders as separate chips

### CORS
- **`CorsConfig`** bound from the `Cors` section; origins matched via `WithOrigins(...)` + `SetIsOriginAllowedToAllowWildcardSubdomains()` (supports `https://*.example.com`; scheme is enforced). Development environment still allows any origin
- **`appsettings.json`**: `Cors:AllowedOrigins` with `gestdown.info`, `*.gestdown.info`, `addictedproxy.pages.dev`, `*.addictedproxy.pages.dev`, `subvault.tv`, `*.subvault.tv`
- **Docs**: new CORS section in `docs/api-surface.md`; pointers in `docs/architecture-overview.md` and `README.md`

## Testing

- New `ParserTests.Test_GetSeasonSubtitles_Splits_Plus_Separated_Scene`: `NTb+playWEB+Kitsune` → `NTb, playWEB, Kitsune`; scenes without `+` unchanged
- New `FetchSubtitlesJobTests` (8 tests): group after first comma, legacy `+` scenes, case-insensitivity, empty/separator-only scenes
- Wildcard-subdomain origin matching verified against `Microsoft.AspNetCore.Cors` (exact origins, `*.` subdomains, scheme enforced, no `evilgestdown.info`-style false positives)
- `AddictedProxy.Upstream.Tests`: 3/3 pass; `AddictedProxy.Services.Tests`: 69/69 pass; full solution build: 0 errors